### PR TITLE
Support for <audio> tag; new trigger; merged events mouse_move / mouse_click; basic script for tracking mouse movement

### DIFF
--- a/app/main/Layout.py
+++ b/app/main/Layout.py
@@ -110,6 +110,11 @@ class Layout:
                                   attributes=[("id", entry.get('id')), ("class", entry.get('class'))],
                                   content=entry.get("content"),
                                   indent=indent)
+            elif entry["type"] == "audio":
+                html += self._tag("audio",
+                                  attributes=attributes,
+                                  content=entry.get("content"),
+                                  indent=indent)
         return html
 
     @staticmethod
@@ -195,6 +200,10 @@ class Layout:
                "}\n"
 
     @staticmethod
+    def _document_ready(content: str):
+        return "$(document).ready(function(){" + content + "});"
+
+    @staticmethod
     def _verify(content: str):
         return content.count("{") == content.count("}")
 
@@ -208,6 +217,8 @@ class Layout:
             return self._submit(content)
         if trigger == "print-history":
             return self._history(content)
+        if trigger == "document-ready":
+            return self._document_ready(content)
         print("unknown trigger:", trigger)
         return ""
 

--- a/app/main/events.py
+++ b/app/main/events.py
@@ -40,20 +40,11 @@ def request_new_image(_name, room, data):
         }, room=room.name())
         log({'type': "new_image", 'room': room.id(), 'url': data[0]})
 
-@socketio.on('mouseMove', namespace='/chat')
-def mouse_move(data):#    emit('drawLine', data['coordinates'], room=Room.from_id(data['room']).name())
-    emit('mouse_move', {
-        'coords' : data['coordinates'][0],
-        'coords_prev' : data['coordinates'][1],
-        'user': current_user.serialize(),
-        'timestamp': timegm(datetime.now().utctimetuple()),
-    }, room=Room.from_id(data['room']).name())
-
-@socketio.on('mouseClick', namespace='/chat')
-def mouse_click(data):
-    emit('mouse_click', {
-        'x': data['coordinates']['x'],
-        'y': data['coordinates']['y'],
+@socketio.on('mousePosition', namespace='/chat')
+def mouse_position(data):
+    emit('mouse_position', {
+        'type': data['type'],
+        'coordinates': data['coordinates'],
         'element': data['element'],
         'user': current_user.serialize(),
         'timestamp': timegm(datetime.now().utctimetuple()),

--- a/app/main/events.py
+++ b/app/main/events.py
@@ -42,10 +42,15 @@ def request_new_image(_name, room, data):
 
 @socketio.on('mousePosition', namespace='/chat')
 def mouse_position(data):
+    """
+    Emit an event 'mouse_position' to pass the coordinates of user clicks
+    or mouse movement (specified via 'type') within an HTML element
+    (specified via 'element').
+    """
     emit('mouse_position', {
-        'type': data['type'],
-        'coordinates': data['coordinates'],
-        'element': data['element'],
+        'type': data.get('type'),
+        'coordinates': data.get('coordinates'),
+        'element': data.get('element'),
         'user': current_user.serialize(),
         'timestamp': timegm(datetime.now().utctimetuple()),
     }, room=Room.from_id(data['room']).name())

--- a/app/static/plugins/mouse-tracking.js
+++ b/app/static/plugins/mouse-tracking.js
@@ -1,6 +1,5 @@
 let trackingArea = "#current-image"
 let mouse = {
-    click: false,
     move: false,
     pos: {x:false, y:false}
 };
@@ -16,7 +15,7 @@ function emitPosition(a) {
         socket.emit('mousePosition', {
             type:'move',
             coordinates:mouse.pos,
-            element:trackingArea,
+            element:a,
             room:self_room
         });
         mouse.move = false;

--- a/app/static/plugins/mouse-tracking.js
+++ b/app/static/plugins/mouse-tracking.js
@@ -1,0 +1,35 @@
+let trackingArea = "#current-image"
+let mouse = {
+    click: false,
+    move: false,
+    pos: {x:false, y:false}
+};
+
+function getPosition (evt, area) {
+    position = $(area).offset();
+    mouse.pos.x = evt.clientX - position.left;
+    mouse.pos.y = evt.clientY - position.top;
+}
+
+function emitPosition(a) {
+    if (mouse.move) {
+        socket.emit('mousePosition', {
+            type:'move',
+            coordinates:mouse.pos,
+            element:trackingArea,
+            room:self_room
+        });
+        mouse.move = false;
+    }
+}
+
+function trackMovement(area,interval) {
+    $(area).mousemove(function(e){
+        getPosition(e, area);
+        mouse.move = true;
+    });
+    setInterval(emitPosition,interval,area)
+}
+
+// get position within trackingArea every 100 ms
+trackMovement(trackingArea, 100);


### PR DESCRIPTION
- events.py : One mouse_position event instead of two separate events for mouse clicks and movement

- Layout.py : <audio> tag can now be used for layout injection; 'document-ready' was added as some kind of default trigger

- mouse-tracking.js : basic script for tracking mouse movement in specific html elements (such as the image area). Can be injected using the trigger 'document-ready'