### PR TITLE
Make `unbeforeunload` a plugin

### DIFF
--- a/app/static/layouts/meetup-task.json
+++ b/app/static/layouts/meetup-task.json
@@ -39,6 +39,7 @@
   "scripts": {
     "incoming-message": "display-message",
     "submit-message": "send-message",
-    "print-history": "plain-history"
+    "print-history": "plain-history",
+    "document-ready": "ask-reload"
   }
 }

--- a/app/static/plugins/ask-reload.js
+++ b/app/static/plugins/ask-reload.js
@@ -1,0 +1,3 @@
+window.onbeforeunload = function () {
+    return "Are you sure you want to leave? Your may not completed the task after reloading or closing the page";
+};

--- a/app/templates/chat.html
+++ b/app/templates/chat.html
@@ -7,10 +7,6 @@
         <script type="text/javascript" src="{{ url_for('static', filename='js/3rd_party/jquery-3.2.1.min.js') }}"></script>
         <script type="text/javascript" src="{{ url_for('static', filename='js/3rd_party/socket.io-2.0.3.min.js') }}"></script>
         <script type="text/javascript" charset="utf-8">
-            window.onbeforeunload = function() {
-                return "Are you sure you want to leave? Your may not completed the task after reloading or closing the page";
-            };
-
             let socket;
             let typing = {};
             let self_user = undefined;


### PR DESCRIPTION
The prompt is annoying when rapidly reloading the page for testing.

I removed `window.unbeforeunload` from `chat.html` and moved it to a new plugin.
The default meetup task uses this plugin.