### PR TITLE
Add `plain` plugin

### DIFF
--- a/app/main/Layout.py
+++ b/app/main/Layout.py
@@ -228,6 +228,8 @@ class Layout:
             return self._history(content)
         if trigger == "document-ready":
             return self._document_ready(content)
+        if trigger == "plain":
+            return content
         print("unknown trigger:", trigger)
         return ""
 

--- a/app/static/layouts/test_room.json
+++ b/app/static/layouts/test_room.json
@@ -32,7 +32,7 @@
         {
           "type": "button",
           "content": "Click me!",
-          "onclick": "alert(\"Hello World!\");"
+          "onclick": "doMyStuff();"
         }
       ]
     },
@@ -54,6 +54,7 @@
   "scripts": {
     "incoming-message": "display-message",
     "submit-message": "send-message",
-    "print-history": "intercept-history"
+    "print-history": "intercept-history",
+    "plain": "do-my-stuff"
   }
 }

--- a/app/static/plugins/do-my-stuff.js
+++ b/app/static/plugins/do-my-stuff.js
@@ -1,0 +1,3 @@
+function doMyStuff() {
+    alert("Hello World!")
+}


### PR DESCRIPTION
The _plain_ plugin simply copies everything from the plugin file into the _chat.html_ `<script>` section.

Please see the changed files for an example.