### PR TITLE
[WIP] Add the ability to add or remove classes from html via bot commands

### DIFF
--- a/app/main/events.py
+++ b/app/main/events.py
@@ -424,6 +424,56 @@ def add_class(data):
          })
 
 
+@socketio.on('remove_class', namespace='/chat')
+@login_required
+def remove_class(data):
+    """
+    Removes the html class from an element by id.
+
+    :param data: A dictionary with the following fields:
+        - ``id``: The id of the element, which is going to be updated
+        - ``class``: The class to be removed
+        - ``receiver_id`` (Optional): Removes the class for this receiver only
+        - ``room`` (Optional): Removes the class for all users in this room. Either ``receiver_id`` or ``room`` is required.
+        - ``sender_id`` (Optional): The sender of the message. Defaults to the current user
+    """
+
+    sender = current_user if 'sender_id' not in data else User.from_id(
+        data['sender_id'])
+
+    if 'id' not in data:
+        print("`remove_class` requires `id`")
+        return
+    if 'class' not in data:
+        print("`remove_class` requires `class`")
+        return
+    if 'receiver_id' in data:
+        user = User.from_id(data['receiver_id'])
+        room = user.latest_room()
+        receiver_id = data['receiver_id']
+        target = User.from_id(receiver_id).sid()
+    elif 'room' in data:
+        room = Room.from_id(data['room'])
+        receiver_id = None
+        target = room.name()
+    else:
+        print("`remove_class` requires `room` or `receiver_id`")
+        return
+
+    emit('class_remove', {
+        'user': sender.serialize(),
+        'timestamp': timegm(datetime.now().utctimetuple()),
+        'id': data['id'],
+        'class': data['class'],
+    }, room=target)
+    log({'type': "class_removed",
+         'room': room.id(),
+         'id': data['id'],
+         'class': data['class'],
+         'receiver': receiver_id
+         })
+
+
 @socketio.on('update_info', namespace='/chat')
 @login_required
 def update_info(data):

--- a/app/static/css/chat.css
+++ b/app/static/css/chat.css
@@ -9,6 +9,10 @@ html, body {
     position: relative;
 }
 
+.hidden {
+    display: none
+}
+
 header, footer {
     min-width: 600px;
     width: 100%;

--- a/app/static/layouts/waiting_room.json
+++ b/app/static/layouts/waiting_room.json
@@ -9,7 +9,8 @@
         {
           "layout-type": "image",
           "id": "current-image",
-          "src": "https://media.giphy.com/media/tXL4FHPSnVJ0A/giphy.gif",
+          "class": "hidden",
+          "src": "",
           "width": 500,
           "height": 400
         }

--- a/app/templates/chat.html
+++ b/app/templates/chat.html
@@ -268,17 +268,27 @@
 
             socket.on('new_image', function (data) {
                 console.log("New image:", data);
-                $('#'+data.id).attr('src', data.url).show();
+                $('#' + data.id).attr('src', data.url).show();
             });
 
             socket.on('attribute_update', function (data) {
                 console.log("Attribute updated:", data);
-                $('#'+data.id).attr(data.attribute, data.value).show();
+                $('#' + data.id).attr(data.attribute, data.value).show();
+            });
+
+            socket.on('class_add', function (data) {
+                console.log("Class added:", data);
+                $('#' + data.id).addClass(data.class);
+            });
+
+            socket.on('class_remove', function (data) {
+                console.log("Class removed:", data);
+                $('#' + data.id).removeClass(data.class);
             });
 
             socket.on('text_update', function (data) {
                 console.log("Text updated:", data);
-                $('#'+data.id).text(data.text).show();
+                $('#' + data.id).text(data.text).show();
             });
         });
     </script>

--- a/docs/slurk_bots.rst
+++ b/docs/slurk_bots.rst
@@ -34,6 +34,20 @@ For this, two functions are provided:
     - ``receiver_id`` (Optional): Sends the text to this receiver only
     - ``room`` (Optional): Sends the text to this room. Either ``receiver_id`` or ``room`` is required
     - ``sender_id`` (Optional): The sender of the message. Defaults to the current user
+- ``add_class``: Adds the html class to an element by id. Those are the fields, which may be passed:
+
+    - ``id``: The id of the element, which is going to be updated
+    - ``text``: The class to be added
+    - ``receiver_id`` (Optional): Adds the class for this receiver only
+    - ``room`` (Optional): Adds the class for all receivers in this room. Either ``receiver_id`` or ``room`` is required
+    - ``sender_id`` (Optional): The sender of the message. Defaults to the current user
+- ``remove_class``: Removes the html class from an element by id. Those are the fields, which may be passed:
+
+    - ``id``: The id of the element, which is going to be updated
+    - ``text``: The class to be removed
+    - ``receiver_id`` (Optional): Removes the class for this receiver only
+    - ``room`` (Optional): Removes the class for all receivers in this room. Either ``receiver_id`` or ``room`` is required
+    - ``sender_id`` (Optional): The sender of the message. Defaults to the current user
 
 If you want to change an image for example, you may use something like this:
 

--- a/sample_bots/pairup_bot.py
+++ b/sample_bots/pairup_bot.py
@@ -80,6 +80,11 @@ class ChatNamespace(BaseNamespace):
             'attribute': "src",
             'value': "https://media.giphy.com/media/tXL4FHPSnVJ0A/giphy.gif"
         })
+        self.emit('remove_class', {
+            'room': data['room']['id'],
+            'id': "current-image",
+            'class': "hidden"
+        })
         self.emit('set_text', {
             'room': data['room']['id'],
             'id': "status-box",
@@ -101,9 +106,22 @@ class ChatNamespace(BaseNamespace):
 
         if data['type'] == 'join':
             print("new user: {}".format(data["user"]["name"]))
-            self.emit("update_info", {'receiver_id': user_id,
-                                      'text': "Patience, we are waiting for another player...",
-                                      })
+            self.emit('set_attribute', {
+                'receiver_id': user_id,
+                'id': "current-image",
+                'attribute': "src",
+                'value': "https://media.giphy.com/media/tXL4FHPSnVJ0A/giphy.gif"
+            })
+            self.emit('remove_class', {
+                'receiver_id': user_id,
+                'id': "current-image",
+                'class': "hidden"
+            })
+            self.emit('set_text', {
+                'receiver_id': user_id,
+                'id': "status-box",
+                'text': "Patience, we are waiting for another player..."
+            })
             tasks[task_id]['users'].add(user_id)
             if user_id not in REG:
                 REG[user_id] = user


### PR DESCRIPTION
- [x] Add ``add_class`` to *events.py*: Adds the html class to an element by id. Those are the fields, which may be passed:

    - ``id``: The id of the element, which is going to be updated
    - ``text``: The class to be added
    - ``receiver_id`` (Optional): Adds the class for this receiver only
    - ``room`` (Optional): Adds the class for all receivers in this room. Either ``receiver_id`` or ``room`` is required
    - ``sender_id`` (Optional): The sender of the message. Defaults to the current user
- [x] Add ``remove_class`` to *events.py*: Removes the html class to an element by id. Those are the fields, which may be passed:

    - ``id``: The id of the element, which is going to be updated
    - ``text``: The class to be removed
    - ``receiver_id`` (Optional): Removes the class for this receiver only
    - ``room`` (Optional): Removes the class for all receivers in this room. Either ``receiver_id`` or ``room`` is required
    - ``sender_id`` (Optional): The sender of the message. Defaults to the current user
- [x] Add functions to *chat.html*
- [x] Adjust documentation
- [x] Add example

### Unresolved questions:
  - [x] Should this be enabled by default or via plugins?