### PR TITLE
Startupscripts update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,6 @@ WTForms == 2.2.1
 
 # Client
 SocketIO-Client == 0.7.2
+
+# Tools
+lxml == 4.3.2

--- a/tools/start_clients.py
+++ b/tools/start_clients.py
@@ -112,6 +112,7 @@ args = parser.parse_args()
 
 # get slurk root directory (parent directory of this file)
 dir_path = dirname(dirname(realpath(__file__)))
+os.chdir(dir_path)
 
 # get information from config file
 config_entries = config_entries(dir_path)

--- a/tools/start_clients.py
+++ b/tools/start_clients.py
@@ -120,9 +120,9 @@ try:
     if browser2:
         current_b = browser2
         browser2 = webbrowser.get(browser2)
-except Exception as exc:
-    print (exc)
-    print ("\nError:\nInvalid browser '{b}'. Please refer to https://docs.python.org/3.7/library/webbrowser.html for supported type names.\n".format(b=current_b))
+except webbrowser.Error as exc:
+    print ("\nError:",exc)
+    print ("Invalid browser '{b}'. Please refer to https://docs.python.org/3.7/library/webbrowser.html for supported type names.\n".format(b=current_b))
     exit()
 client_names = config_entries['client-names'].split(',')
 secret_key = config_entries['secret-key']
@@ -131,9 +131,9 @@ if __name__ == "__main__":
     # get the links (length of client_names is number of clients)
     try:
         links =  get_client_links(client_names, key=secret_key, testroom=args.testroom)
-    except Exception as exc:
-        print ('\nError: \n', sys.exc_info())
-        print ('\nCould not connect to Slurk server! Is it running?')
+    except requests.exceptions.ConnectionError as exc:
+        print ('\nError: \n', sys.exc_info()[1])
+        print ('\nCould not connect to server! Is it running?')
         exit()
     # open generated links using the web browsers specified in config file
     # if browser1 or browser2 is False: use default web browser
@@ -143,6 +143,7 @@ if __name__ == "__main__":
                 browser1.open(link) if browser1 else webbrowser.open(link)
             else:
                 browser2.open(link) if browser2 else webbrowser.open(link)
-        except:
-            print ('ERROR: could not open link in web browser!')
+        except Exception as exc:
+            print ('\nError: \n', sys.exc_info())
+            print ('\nCould not open link in web browser! Try starting the browser first and then re-running the script.')
         sleep(1)

--- a/tools/start_clients.py
+++ b/tools/start_clients.py
@@ -5,23 +5,83 @@ import lxml.html
 import configparser
 import sys
 import os
+import argparse
 from os.path import dirname, realpath
 from time import sleep
+from shutil import copyfile
+from string import ascii_letters, digits, punctuation
+from random import choices
 
-# use dirname twice to get parent directory of current file
-dir_path = dirname(dirname(realpath(__file__)))
-os.chdir(dir_path)
 
-config = configparser.ConfigParser()
-config.read('config.ini')
-secret_key = config['server']['secret-key']
+def config_entries(dir=os.getcwd()):
+    """
+        retrieve information from config file
+        if there's no config.ini in provided directory: copy config.template.ini
+        assign default values to missing entries
+    """
+    config = configparser.ConfigParser()
+    if 'config.ini' not in os.listdir(dir):
+        # copy template file if config.ini doesn't exist
+        print ('creating config file')
+        copyfile(dir+'/config.template.ini', dir+'/config.ini')
+    config.read(dir+'/config.ini')
 
-browser1 = webbrowser.get(config['tools']['browser1'])
-browser2 = webbrowser.get(config['tools']['browser2'])
-client_names = config['tools']['client_names'].split(',')
+    if not 'tools' in config.sections():
+        config.add_section('tools')
 
-def get_client_links(names, key):
+    # web browsers
+    browsers = {'browser1':False,'browser2':False}
+    for entry in browsers:
+        try:
+            # run exception if browser is not found or is empty string
+            val = config['tools'][entry]
+            if len(val) == 0:
+                raise Exception('invalid web browser')
+            browsers[entry] = val
+        except:
+            print ("\nKey '{browser}' is not set in config.ini! Attempting to use default browser. \nPlease specify in the config file which web browser you want to use!".format(browser=entry))
+            # write default value for browser to config file
+            config['tools'][entry] = ''
+            with open('config.ini', 'w') as configfile:
+                config.write(configfile)
+
+    # client names
+    try:
+        names = config['tools']['client-names']
+        if len(names) == 0:
+            raise Exception('no client names found')
+    except:
+        print ('\nNo client names found in config.ini! Setting default names.')
+        # write client names to config file
+        names = 'client1,client2'
+        config['tools']['client-names'] = names
+        with open('config.ini', 'w') as configfile:
+            config.write(configfile)
+
+    # secret key
+    try:
+        # run exception if secret-key is not found or is empty string
+        s_key = config['server']['secret-key']
+        if len(s_key) == 0:
+            raise Exception('invalid secret key')
+    except:
+        print ('generating secret key')
+        # generate secret key with length = 17
+        chars = ascii_letters + digits + punctuation.replace('%', '')
+        s_key = ''.join(choices(chars, k=17))
+        # write secret key to config file
+        config['server']['secret-key'] = s_key
+        with open('config.ini', 'w') as configfile:
+            config.write(configfile)
+
+    return {**browsers, 'client-names':names, 'secret-key':s_key}
+
+def get_client_links(names, key, testroom):
     """ return links to log in as a client """
+
+    # get links for test room or waiting room
+    room = 2 if testroom else 1
+
     links= []
     for i in names:
         name = i
@@ -31,7 +91,7 @@ def get_client_links(names, key):
         source = lxml.html.document_fromstring(r.content)
         token = source.xpath('//input[@name="csrf_token"]/@value')[0]
         headers = {'Referer': 'http://127.0.0.1:5000/token'}
-        data = {'csrf_token': token, 'room': '1', 'task': '1', 'source': name, 'key': key}
+        data = {'csrf_token': token, 'room': room, 'task': '1', 'source': name, 'key': key}
         login_token = s.post(url, data=data, headers=headers).text
         if login_token.endswith('<br />'):
             login_token = login_token[:-6]
@@ -39,15 +99,35 @@ def get_client_links(names, key):
         links.append(uris)
     return links
 
-if __name__ == "__main__":
+parser = argparse.ArgumentParser()
+parser.add_argument('--testroom', help='connect clients to test room',
+    action='store_true')
+args = parser.parse_args()
 
+# use dirname twice to get parent directory of current file
+dir_path = dirname(dirname(realpath(__file__)))
+os.chdir(dir_path)
+
+# get information from config file
+config_entries = config_entries()
+browser1 = config_entries['browser1']
+if browser1:
+    browser1 = webbrowser.get(browser1)
+browser2 = config_entries['browser2']
+if browser2:
+    browser2 = webbrowser.get(browser2)
+client_names = config_entries['client-names'].split(',')
+secret_key = config_entries['secret-key']
+
+if __name__ == "__main__":
     # get the links (length of client_names is number of clients)
-    links =  get_client_links(client_names, key=secret_key)
+    links =  get_client_links(client_names, key=secret_key, testroom=args.testroom)
 
     # open generated links using the web browsers specified in config file
+    # if browser1 or browser2 is False: use default web browser
     for i,link in list(enumerate(links)):
         if i%2 == 0:
-            browser1.open(link)
+            browser1.open(link) if browser1 else webbrowser.open(link)
         else:
-            browser2.open(link)
+            browser2.open(link) if browser2 else webbrowser.open(link)
         sleep(1)

--- a/tools/start_clients.py
+++ b/tools/start_clients.py
@@ -83,12 +83,13 @@ def config_entries(dir=os.getcwd()):
 def get_client_links(names, key, testroom):
     """ return links to log in as a client """
 
-    # get links for test room or waiting room
+    # room = 1 -> Waiting Room, room = 2 -> Test Room
     room = 2 if testroom else 1
 
     links= []
     for i in names:
         name = i
+        # retrieve token
         url = 'http://{host}:{port}/token'.format(host=host,port=port)
         s = requests.session()
         r = s.get(url)
@@ -99,6 +100,7 @@ def get_client_links(names, key, testroom):
         login_token = s.post(url, data=data, headers=headers).text
         if login_token.endswith('<br />'):
             login_token = login_token[:-6]
+        # create link with token
         uris = 'http://{host}:{port}/?name={name}&token={token}'.format(host=host,port=port,name=name,token=login_token)
         links.append(uris)
     return links
@@ -108,9 +110,8 @@ parser.add_argument('--testroom', help='connect clients to test room',
     action='store_true')
 args = parser.parse_args()
 
-# use dirname twice to get parent directory of current file
+# get slurk root directory (parent directory of this file)
 dir_path = dirname(dirname(realpath(__file__)))
-os.chdir(dir_path)
 
 # get information from config file
 config_entries = config_entries(dir_path)
@@ -133,13 +134,15 @@ host = config_entries['host']
 port = config_entries['port']
 
 if __name__ == "__main__":
-    # get the links (length of client_names is number of clients)
+
+    # get links for connecting (length of client_names is number of clients)
     try:
         links =  get_client_links(client_names, key=secret_key, testroom=args.testroom)
     except requests.exceptions.ConnectionError as exc:
         print ('\nError: \n', sys.exc_info()[1])
         print ('\nCould not connect to server! Is it running?')
         exit()
+
     # open generated links using the web browsers specified in config file
     # if browser1 or browser2 is False: use default web browser
     for i,link in list(enumerate(links)):

--- a/tools/start_server_and_bot.py
+++ b/tools/start_server_and_bot.py
@@ -90,7 +90,7 @@ if not (args.nopairup or args.testroom):
     bots.insert(0, dir_path+'/sample_bots/pairup_bot.py')
 
 # get secret key from config.ini
-secret_key = config_entries()['secret-key']
+secret_key = config_entries(dir_path)['secret-key']
 
 if __name__ == "__main__":
     # print basic information

--- a/tools/start_server_and_bot.py
+++ b/tools/start_server_and_bot.py
@@ -9,43 +9,94 @@ import subprocess
 import signal
 import atexit
 from time import sleep
+from shutil import copyfile
+from string import ascii_letters, digits, punctuation
+from random import choices
 
-parser = argparse.ArgumentParser()
-parser.add_argument('bot', nargs='*', help='path to bot file')
-args = parser.parse_args()
 
-# get absolute paths for all bot files
-bots = [abspath(bot) for bot in args.bot]
-nullfile = open(os.devnull, "w")
+def get_bot_token(name, key, testroom):
+    """
+    get a token for connecting a bot
+    """
+    # get token for test room or waiting room
+    room = 2 if testroom else 1
 
-# use dirname twice to move to parent directory of current file (i.e. root folder of slurk)
-dir_path = dirname(dirname(realpath(__file__)))
-os.chdir(dir_path)
-
-# get secret key from config.ini
-config = configparser.ConfigParser()
-config.read('config.ini')
-secret_key = config['server']['secret-key']
-
-def get_bot_token(name, key):
-    """ get a token for connecting a bot """
     url = 'http://127.0.0.1:5000/token'
     s = requests.session()
     r = s.get(url)
     source = document_fromstring(r.content)
     token = source.xpath('//input[@name="csrf_token"]/@value')[0]
     headers = {'Referer': 'http://127.0.0.1:5000/token'}
-    data = {'csrf_token': token, 'room': '1', 'task': '2', 'reusable': 'y', 'source': name, 'key': key}
+    data = {'csrf_token': token,
+            'room': room,
+            'task': '2',
+            'reusable': 'y',
+            'source': name,
+            'key': key
+            }
     login_token = s.post(url, data=data, headers=headers).text
     if login_token.endswith('<br />'):
         login_token = login_token[:-6]
     return login_token
+
+def config_entries(dir=os.getcwd()):
+    """
+        retrieve information from config file
+        if there's no config.ini in provided directory: copy config.template.ini
+        generate secret key if none is found in config.ini
+    """
+    config = configparser.ConfigParser()
+    if 'config.ini' not in os.listdir(dir):
+        # copy template file if config.ini doesn't exist
+        print ('creating config file')
+        copyfile(dir+'/config.template.ini', dir+'/config.ini')
+    config.read(dir+'/config.ini')
+
+    try:
+        # run exception if secret-key is not found or is empty string
+        s_key = config['server']['secret-key']
+        if len(s_key) == 0:
+            raise Exception('invalid secret key')
+    except:
+        print ('generating secret key')
+        # generate secret key with length = 17
+        s_key = ''.join(choices(ascii_letters + digits + punctuation, k=17))
+        # write secret key to config file
+        config['server']['secret-key'] = s_key
+        with open('config.ini', 'w') as configfile:
+            config.write(configfile)
+
+    return {
+        'secret-key': s_key
+    }
+
+parser = argparse.ArgumentParser()
+parser.add_argument('bot', nargs='*', help='path to bot file')
+parser.add_argument('--testroom', help='connect bots to test room',
+    action='store_true')
+parser.add_argument('--nopairup', help='do not start pairup bot automatically',
+    action='store_true')
+args = parser.parse_args()
+
+# get absolute paths for all bot files
+bots = [abspath(bot) for bot in args.bot]
+# move to slurk root folder
+dir_path = dirname(dirname(realpath(__file__)))
+os.chdir(dir_path)
+
+if not (args.nopairup or args.testroom):
+    # set pairup bot as the first bot to be started
+    bots.insert(0, dir_path+'/sample_bots/pairup_bot.py')
+
+# get secret key from config.ini
+secret_key = config_entries()['secret-key']
 
 if __name__ == "__main__":
     # print basic information
     print ("Directory:",dir_path)
     print ("Bots: ",bots, "\n")
     processes = []
+    nullfile = open(os.devnull, "w")
 
     # start slurk
     server = subprocess.Popen('python {path}/chat.py'.format(path=dir_path), shell=True)
@@ -60,7 +111,7 @@ if __name__ == "__main__":
         bot_dir = dirname(i)
         bot_filename = basename(i)
         os.chdir(bot_dir)
-        token = get_bot_token(bot_filename, secret_key)
+        token = get_bot_token(bot_filename, secret_key, args.testroom)
 
         print ("starting", i, "\ntoken:", token)
 

--- a/tools/start_server_and_bot.py
+++ b/tools/start_server_and_bot.py
@@ -14,6 +14,38 @@ from string import ascii_letters, digits, punctuation
 from random import choices
 
 
+def config_entries(dir=os.getcwd()):
+    """
+        retrieve information from config file
+        if there's no config.ini in provided directory: copy config.template.ini
+        generate secret key if none is found in config.ini
+    """
+    config = configparser.ConfigParser()
+    if 'config.ini' not in os.listdir(dir):
+        # copy template file if config.ini doesn't exist
+        print ('creating config file')
+        copyfile(dir+'/config.template.ini', dir+'/config.ini')
+    config.read(dir+'/config.ini')
+
+    try:
+        # run exception if secret-key is not found or is empty string
+        s_key = config['server']['secret-key']
+        if len(s_key) == 0:
+            raise Exception('invalid secret key')
+    except:
+        print ('generating secret key')
+        # generate secret key with length = 17
+        chars = ascii_letters + digits + punctuation.replace('%', '')
+        s_key = ''.join(choices(chars, k=17))
+        # write secret key to config file
+        config['server']['secret-key'] = s_key
+        with open('config.ini', 'w') as configfile:
+            config.write(configfile)
+
+    return {
+        'secret-key': s_key
+    }
+
 def get_bot_token(name, key, testroom):
     """
     get a token for connecting a bot
@@ -38,37 +70,6 @@ def get_bot_token(name, key, testroom):
     if login_token.endswith('<br />'):
         login_token = login_token[:-6]
     return login_token
-
-def config_entries(dir=os.getcwd()):
-    """
-        retrieve information from config file
-        if there's no config.ini in provided directory: copy config.template.ini
-        generate secret key if none is found in config.ini
-    """
-    config = configparser.ConfigParser()
-    if 'config.ini' not in os.listdir(dir):
-        # copy template file if config.ini doesn't exist
-        print ('creating config file')
-        copyfile(dir+'/config.template.ini', dir+'/config.ini')
-    config.read(dir+'/config.ini')
-
-    try:
-        # run exception if secret-key is not found or is empty string
-        s_key = config['server']['secret-key']
-        if len(s_key) == 0:
-            raise Exception('invalid secret key')
-    except:
-        print ('generating secret key')
-        # generate secret key with length = 17
-        s_key = ''.join(choices(ascii_letters + digits + punctuation, k=17))
-        # write secret key to config file
-        config['server']['secret-key'] = s_key
-        with open('config.ini', 'w') as configfile:
-            config.write(configfile)
-
-    return {
-        'secret-key': s_key
-    }
 
 parser = argparse.ArgumentParser()
 parser.add_argument('bot', nargs='*', help='path to bot file')

--- a/tools/start_server_and_bot.py
+++ b/tools/start_server_and_bot.py
@@ -31,15 +31,15 @@ def config_entries(dir=os.getcwd()):
     port = config['server']['port']
 
     try:
-        # run exception if secret-key is not found or is empty string
+        # run exception if secret-key is not found or empty
         s_key = config['server']['secret-key']
         if len(s_key) == 0:
             raise Exception('invalid secret key')
     except:
         print ('generating secret key')
-        # generate secret key with length = 17
+        # generate secret key (16 characters)
         chars = ascii_letters + digits + punctuation.replace('%', '')
-        s_key = ''.join(choices(chars, k=17))
+        s_key = ''.join(choices(chars, k=16))
         # write secret key to config file
         config['server']['secret-key'] = s_key
         with open('config.ini', 'w') as configfile:
@@ -53,9 +53,10 @@ def get_bot_token(name, key, testroom):
     """
     get a token for connecting a bot
     """
-    # get token for test room or waiting room
+    # room = 1 -> Waiting Room, room = 2 -> Test Room
     room = 2 if testroom else 1
 
+    # retrieve token
     url = 'http://{host}:{port}/token'.format(host=host,port=port)
     s = requests.session()
     r = s.get(url)
@@ -84,7 +85,7 @@ args = parser.parse_args()
 
 # get absolute paths for all bot files
 bots = [abspath(bot) for bot in args.bot]
-# move to slurk root folder
+# move to slurk root folder (parent directory of this file)
 dir_path = dirname(dirname(realpath(__file__)))
 os.chdir(dir_path)
 
@@ -100,6 +101,7 @@ port = config_entries['port']
 
 
 if __name__ == "__main__":
+
     # print basic information
     print ("Directory:",dir_path)
     print ("Bots: ",bots, "\n")
@@ -108,7 +110,6 @@ if __name__ == "__main__":
 
     # start slurk
     server = subprocess.Popen(['python','{path}/chat.py'.format(path=dir_path)])
-
     # add process id to list of running processes
     processes.append(server.pid)
 
@@ -129,6 +130,7 @@ if __name__ == "__main__":
         # add process id to list of running processes
         processes.append(bot_process.pid)
         sleep(1)
+
     # clean up at exit
     def terminate_processes():
         """
@@ -136,7 +138,7 @@ if __name__ == "__main__":
         """
         print ('terminating processes')
         for process in processes[::-1]:
-            os.kill(os.getpgid(process), signal.SIGTERM)
+            os.killpg(os.getpgid(process), signal.SIGTERM)
         nullfile.close()
 
     # register exit handler


### PR DESCRIPTION
Added some features to the startup scripts: 
- the Pairup Bot is now connected by default if `start_server_and_bot.py` is run (can be prevented using the argument `--nopairup`)
- `start_server_and_bot.py` and `start_clients.py` can optionally be run with the argument `--testroom` in order to connect bots/clients to the test room
- the config file is checked for completeness in both scripts - if none exists, a new config file is created; missing entries are filled in (in most cases, exception: if no web browser is specified, the default browser is used)
- host and port are retrieved from the config file in both scripts
- exception messages for common sources of error (e.g. if the browser specified in the config file can't be found)

Two issues for Mac couldn't be solved yet:
- Opera couldn't be set as a browser
- some browsers have to be started manually before running `start_clients.py` (error observed for Chrome)